### PR TITLE
major refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package is currently very much in an alpha state. No guarantees on what may
 
 ## Features
 
-- **Easy Integration**: Simple setup for Cobra CLI applications
+- **Easy Integration**: Extremely simple setup for new and existing Cobra CLI applications
 - **Signal Handling**: Proper signal handling for graceful shutdowns
 
 ## Installation
@@ -18,6 +18,8 @@ go get github.com/iamkirkbater/cobra-otel-metrics
 ## Quick Start
 
 ### Basic Usage
+
+Simply create one or many otel exporters, wrap your root command in a `metrics.Command` wrapper, and then run the metrics setup function passing in your exporter(s).
 
 See the `examples` in the [examples](/examples) directory for usage examples.
 

--- a/examples/00-minimal/minimal.go
+++ b/examples/00-minimal/minimal.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	metrics "github.com/iamkirkbater/cobra-otel-metrics"
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
+)
+
+func main() {
+	var rootCmd = metrics.Command{
+		Command: cobra.Command{
+			Use:   "minimal",
+			Short: "Example minimal CLI application with OpenTelemetry metrics",
+			Run:   runExample,
+		},
+	}
+
+	stdoutExporter, _ := stdoutmetric.New()
+
+	rootCmd.SetupMetrics(
+		metrics.WithExporter(stdoutExporter),
+	)
+
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func runExample(cmd *cobra.Command, args []string) {
+	fmt.Println("Hello World")
+}

--- a/examples/01-subcommand-with-flags/subcommand.go
+++ b/examples/01-subcommand-with-flags/subcommand.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	metrics "github.com/iamkirkbater/cobra-otel-metrics"
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
+)
+
+var testFlag bool
+var stringFlag string
+
+func main() {
+	var rootCmd = metrics.Command{
+		Command: cobra.Command{
+			Use:   "sub",
+			Short: "Example CLI application with OpenTelemetry metrics",
+			Run: func(cmd *cobra.Command, args []string) {
+				cmd.Usage()
+			},
+		},
+	}
+
+	stdoutExporter, _ := stdoutmetric.New()
+
+	rootCmd.SetupMetrics(
+		metrics.WithExporter(stdoutExporter),
+	)
+
+	subCmd := &cobra.Command{
+		Use:  "my-subcommand",
+		Args: cobra.NoArgs,
+		Run:  runSubCmd,
+	}
+	flags := subCmd.Flags()
+	flags.BoolVarP(&testFlag, "test", "t", false, "test flag for command")
+	flags.StringVarP(&stringFlag, "string", "s", "", "a random string to pass")
+
+	anotherChildCmd := &cobra.Command{
+		Use:  "child",
+		Args: cobra.NoArgs,
+		Run:  runSubCmd,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			fmt.Println("In the child cmd persistent pre-run")
+		},
+	}
+
+	grandChildCommand := &cobra.Command{
+		Use:  "grandchild",
+		Args: cobra.NoArgs,
+		Run:  runSubCmd,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("In the grandchild command pre-run")
+			return nil
+		},
+	}
+
+	grandChildFlags := grandChildCommand.Flags()
+	grandChildFlags.StringVarP(&stringFlag, "string", "s", "", "a random string to pass")
+	anotherChildCmd.AddCommand(grandChildCommand)
+
+	rootCmd.AddCommand(subCmd)
+	rootCmd.AddCommand(anotherChildCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func runSubCmd(cmd *cobra.Command, args []string) {
+	fmt.Println("Flag Values")
+	fmt.Printf(" - testFlag: %t\n", testFlag)
+	fmt.Printf(" - stringFlag: %s\n", stringFlag)
+}

--- a/examples/02-additional-metrics/additional-metrics.go
+++ b/examples/02-additional-metrics/additional-metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	metrics "github.com/iamkirkbater/cobra-otel-metrics"
@@ -13,23 +14,29 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+// This example shows how you can create additional metrics to pass into your
+// application to have it measure additional things.
+
 func main() {
-	var rootCmd = &cobra.Command{
-		Use:   "example",
-		Short: "Example CLI application with OpenTelemetry metrics",
-		RunE:  runExample,
+	var rootCmd = metrics.Command{
+		Command: cobra.Command{
+			Use:   "example",
+			Short: "Example CLI application with OpenTelemetry metrics",
+			RunE:  runExample,
+		},
 	}
 
-	stdoutExp, err := stdoutmetric.New()
+	stdErrExp, err := stdoutmetric.New(
+		stdoutmetric.WithPrettyPrint(),
+		stdoutmetric.WithWriter(os.Stderr),
+	)
 	if err != nil {
 		log.Fatal("Failed to setup stdoutExporter:", err)
 	}
 
-	// Setup metrics for the Cobra command
-	err = metrics.SetupCobraMetrics(
-		rootCmd,
-		metrics.WithServiceName("example-service"), // Service name
-		metrics.WithExporter(stdoutExp),
+	rootCmd.SetupMetrics(
+		metrics.WithServiceName("example-service"),
+		metrics.WithExporter(stdErrExp),
 	)
 	if err != nil {
 		log.Fatal("Failed to setup metrics:", err)

--- a/internal/command.go
+++ b/internal/command.go
@@ -1,0 +1,43 @@
+package internal
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// Returns the full subcommand path without the root command
+// however if the root command is the only command called we
+// return "root"
+func ParseCmdName(cmd *cobra.Command) string {
+	cmdString := cmd.CommandPath()
+	stringArr := strings.Split(cmdString, " ")
+	if len(stringArr) == 1 {
+		return "root"
+	}
+	stringArr = stringArr[1:]
+	return strings.Join(stringArr, "-")
+}
+
+// Returns the root command name
+func GetRootCmdName(cmd *cobra.Command) string {
+	cmdString := cmd.CommandPath()
+	stringArr := strings.Split(cmdString, " ")
+	return stringArr[0]
+}
+
+// Loops through all provided flags and converts ONLY the
+// name of the flag (NOT THE VALUE) to an attribute for
+// additional metric collection
+func ParseCmdFlagsToAttributes(cmd *cobra.Command) attribute.Set {
+	flags := []attribute.KeyValue{}
+	parseFlag := func(f *pflag.Flag) {
+		flags = append(flags, attribute.String(f.Name, "1"))
+	}
+	cmd.Flags().Visit(parseFlag)
+
+	flagsAttrSet, _ := attribute.NewSetWithFiltered(flags, nil)
+	return flagsAttrSet
+}

--- a/internal/metrics.go
+++ b/internal/metrics.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 	metricSdk "go.opentelemetry.io/otel/sdk/metric"
@@ -13,9 +14,8 @@ import (
 )
 
 type Config struct {
-	PrintToStdout bool
-	ServiceName   string
-	Exporters     []metricSdk.Exporter
+	ServiceName string
+	Exporters   []metricSdk.Exporter
 }
 
 type MetricsProvider struct {
@@ -29,9 +29,9 @@ var (
 	Exporters []metricSdk.Exporter
 )
 
-func NewConfig(opts ...Option) (*Config, error) {
+func NewConfig(cmd *cobra.Command, opts ...Option) (*Config, error) {
 	config := &Config{
-		PrintToStdout: false,
+		ServiceName: GetRootCmdName(cmd),
 	}
 
 	for _, opt := range opts {
@@ -69,25 +69,6 @@ func NewMetricsProvider(ctx context.Context, config *Config) (*MetricsProvider, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
-
-	// if config.Exporters.GRPC != nil {
-	// 	grpcConfig := config.Exporters.GRPC
-	// 	// Create OTLP exporter
-	// 	var dialOpts []grpc.DialOption
-	// 	if grpcConfig.AllowInsecure {
-	// 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	// 	}
-
-	// 	exporter, err := otlpmetricgrpc.New(ctx,
-	// 		otlpmetricgrpc.WithEndpoint(config.Exporters.GRPC.CollectorURL),
-	// 		otlpmetricgrpc.WithDialOption(dialOpts...),
-	// 	)
-	// 	if err != nil {
-	// 		return nil, fmt.Errorf("failed to create OTLP exporter: %w", err)
-	// 	}
-
-	// 	Exporters = append(Exporters, exporter)
-	// }
 
 	provider := metricSdk.NewMeterProvider(
 		metricSdk.WithResource(res),

--- a/internal/options.go
+++ b/internal/options.go
@@ -18,14 +18,6 @@ type applier interface {
 	apply(*Config) error
 }
 
-// func WithGrpcExporter(opts ...Option) Option {
-// 	grpcCfg := &ExporterConfig{}
-// 	return option(func(cfg *Config) error {
-// 		cfg.Exporters.GRPC = grpcCfg
-// 		return nil
-// 	})
-// }
-
 func WithExporter(exporter metricSdk.Exporter) Option {
 	return option(func(cfg *Config) error {
 		if cfg.Exporters == nil {
@@ -36,34 +28,10 @@ func WithExporter(exporter metricSdk.Exporter) Option {
 	})
 }
 
-// // WithCollectorURL sets the URL for the metrics collector
-// func WithCollectorURL(url string) Option {
-// 	return option(func(cfg *Config) error {
-// 		cfg.CollectorURL = url
-// 		return nil
-// 	})
-// }
-//
-// // WithInsecure allows insecure connections to the collector
-// func WithInsecure(insecure bool) Option {
-// 	return option(func(cfg *Config) error {
-// 		cfg.AllowInsecure = insecure
-// 		return nil
-// 	})
-// }
-
 // WithServiceName sets the service name for metrics
 func WithServiceName(name string) Option {
 	return option(func(cfg *Config) error {
 		cfg.ServiceName = name
-		return nil
-	})
-}
-
-// WithStdoutPrint enables printing metrics to stdout for debugging
-func WithStdoutPrint(enabled bool) Option {
-	return option(func(cfg *Config) error {
-		cfg.PrintToStdout = enabled
 		return nil
 	})
 }

--- a/main.go
+++ b/main.go
@@ -14,16 +14,178 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
-type (
-	Option = internal.Option
+type Option = internal.Option
+
+// Exposed Options
+var (
+	// Optional configuration to set the service name
+	// this will default to your root command name
+	WithServiceName = internal.WithServiceName
+
+	// Can be passed multiple times to add many exporters
+	WithExporter = internal.WithExporter
 )
+
+// Extend the cobra.Command struct here to allow drop-in replacement
+// of the root command while also giving us a place to store context
+// and other things we may need
+type Command struct {
+	cobra.Command
+
+	ctx context.Context
+}
+
+// SetupMetrics is a convenience function to set up metrics for a Cobra command
+// It initializes the metrics provider and sets up a cleanup handler
+func (c *Command) SetupMetrics(options ...Option) error {
+	ctx := context.Background()
+
+	_, err := initialize(ctx, &c.Command, options...)
+	if err != nil {
+		return fmt.Errorf("failed to initialize metrics: %w", err)
+	}
+
+	wrapPreRun(&c.Command, true)
+	wrapPostRun(&c.Command, true)
+
+	c.ctx = ctx
+	return nil
+}
+
+func wrapPostRun(cmd *cobra.Command, force bool) {
+	originalPostRunE := cmd.PersistentPostRunE
+	originalPostRun := cmd.PersistentPostRun
+	if originalPostRunE != nil || originalPostRun != nil || force {
+		cmd.PersistentPostRunE = func(cmd *cobra.Command, args []string) error {
+			var originalPostRunErr error
+			// Run original PostRunE if it exists
+			if originalPostRunE != nil {
+				if err := originalPostRunE(cmd, args); err != nil {
+					originalPostRunErr = err
+				}
+			}
+
+			// return the original error if it exists
+			return originalPostRunErr
+		}
+	}
+}
+
+func wrapPreRun(cmd *cobra.Command, force bool) {
+	originalPreRunE := cmd.PersistentPreRunE
+	originalPreRun := cmd.PersistentPreRun
+	if originalPreRunE != nil || originalPreRun != nil || force {
+		cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+			// create the initial metric around the command called
+			err := createInvocationMetric(cmd)
+			if err != nil {
+				return err
+			}
+
+			// Run original PreRunE if it exists
+			if originalPreRunE != nil {
+				return originalPreRunE(cmd, args)
+			}
+			return nil
+		}
+	}
+}
+
+func wrapSubCommandRunHooks(cmd *cobra.Command) {
+	wrapPreRun(cmd, false)
+	wrapPostRun(cmd, false)
+	wrapHelpFunc(cmd)
+	children := cmd.Commands()
+	for i := range children {
+		wrapSubCommandRunHooks(children[i])
+	}
+}
+
+func wrapHelpFunc(cmd *cobra.Command) {
+	oldHelpFunc := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		createInvocationMetric(cmd)
+		oldHelpFunc(cmd, args)
+	})
+}
+
+func (c *Command) Execute() error {
+	// catch trap signals and send metrics if we can
+	c.trap()
+
+	for _, command := range c.Command.Commands() {
+		wrapSubCommandRunHooks(command)
+	}
+
+	// Run the command
+	err := c.Command.Execute()
+
+	// push metrics even if the command wasn't successful
+	c.cleanup()
+
+	return err
+}
+
+func (c *Command) trap() {
+	// Trap Command Cancellations
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-ch
+		c.cleanup()
+		os.Exit(1)
+	}()
+
+}
+
+func (c *Command) cleanup() {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	collectedMetrics := &metricdata.ResourceMetrics{}
+	internal.Reader.Collect(c.ctx, collectedMetrics)
+
+	for _, exporter := range internal.Exporters {
+		exporter.Export(c.ctx, collectedMetrics)
+	}
+
+	if err := shutdown(shutdownCtx); err != nil {
+		fmt.Fprintf(os.Stderr, "Error shutting down metrics provider: %v\n", err)
+	}
+}
+
+func createInvocationMetric(cmd *cobra.Command) error {
+	// Create a counter metric
+	counter, err := GetMeter().Int64Counter(
+		internal.ParseCmdName(cmd),
+		metric.WithDescription("Command Invocation"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create counter: %w", err)
+	}
+
+	counter.Add(context.Background(), 1, metric.WithAttributeSet(internal.ParseCmdFlagsToAttributes(cmd)))
+
+	return nil
+}
 
 // Global metrics provider instance
 var globalProvider *internal.MetricsProvider
 
+// GetMeter returns the meter for creating instruments
+func GetMeter() metric.Meter {
+	return globalProvider.GetMeter()
+}
+
+// shutdown gracefully shuts down the metrics provider
+func shutdown(ctx context.Context) error {
+	return globalProvider.Shutdown(ctx)
+}
+
 // initialize sets up the metrics provider with the given options
-func initialize(ctx context.Context, options ...Option) (*internal.MetricsProvider, error) {
-	config, err := internal.NewConfig(options...)
+func initialize(ctx context.Context, cmd *cobra.Command, options ...Option) (*internal.MetricsProvider, error) {
+	config, err := internal.NewConfig(cmd, options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config: %w", err)
 	}
@@ -37,88 +199,3 @@ func initialize(ctx context.Context, options ...Option) (*internal.MetricsProvid
 
 	return provider, nil
 }
-
-// GetMeter returns the meter for creating instruments
-func GetMeter() metric.Meter {
-	return globalProvider.GetMeter()
-}
-
-// Shutdown gracefully shuts down the metrics provider
-func Shutdown(ctx context.Context) error {
-	return globalProvider.Shutdown(ctx)
-}
-
-// SetupCobraMetrics is a convenience function to set up metrics for a Cobra command
-// It initializes the metrics provider and sets up a cleanup handler
-func SetupCobraMetrics(cmd *cobra.Command, options ...Option) error {
-	// Initialize metrics provider
-	ctx := context.Background()
-	provider, err := initialize(ctx, options...)
-	if err != nil {
-		return fmt.Errorf("failed to initialize metrics: %w", err)
-	}
-
-	cleanupFunc := func() {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-		defer cancel()
-
-		collectedMetrics := &metricdata.ResourceMetrics{}
-		internal.Reader.Collect(ctx, collectedMetrics)
-
-		for _, exporter := range internal.Exporters {
-			exporter.Export(ctx, collectedMetrics)
-		}
-
-		if err := provider.Shutdown(shutdownCtx); err != nil {
-			fmt.Fprintf(os.Stderr, "Error shutting down metrics provider: %v\n", err)
-		}
-	}
-
-	// Set up cleanup on command completion
-	// This is set up so that we can trap and still report metrics if
-	// the command is exited prematurely
-	originalPreRun := cmd.PreRunE
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		// Set up signal handling for graceful shutdown
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-		go func() {
-			<-c
-			cleanupFunc()
-			os.Exit(1)
-		}()
-
-		// Run original PreRunE if it exists
-		if originalPreRun != nil {
-			return originalPreRun(cmd, args)
-		}
-		return nil
-	}
-
-	// Set up cleanup on command completion
-	// This is needed in addition to the trap running above
-	originalPostRun := cmd.PostRunE
-	cmd.PostRunE = func(cmd *cobra.Command, args []string) error {
-		var originalPostRunErr error
-		// Run original PostRunE if it exists
-		if originalPostRun != nil {
-			if err := originalPostRun(cmd, args); err != nil {
-				originalPostRunErr = err
-			}
-		}
-
-		cleanupFunc()
-
-		// return the original error if it exists
-		return originalPostRunErr
-	}
-
-	return nil
-}
-
-// Convenience functions for creating options
-var (
-	WithServiceName = internal.WithServiceName
-	WithStdoutPrint = internal.WithStdoutPrint
-	WithExporter    = internal.WithExporter
-)


### PR DESCRIPTION
Major refactor of the package. 

* Much more user friendly.
* Extends cobra.Command struct so that it's almost entirely drop in for existing appilcations
* Provides a single metric for call invocations by default
* Adds ability to provide flag NAMES (not values) as metrics by default
* Removes the need to provide a service name, it now defaults to the name of the application as defined in the rootCmd
* Behind the scenes it wraps any PersistentPreRun or PersistentPreRunE functions defined by users so that we still get metrics
* Wraps provided help functions so that we still get metrics when `--help` is called (if a LOT of users are running `--help` on the same command maybe it means we invest in usability on that command)