### PR TITLE
refactors the name of the metric to be more consistent

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,7 +140,6 @@ func (c *Command) trap() {
 		c.cleanup()
 		os.Exit(1)
 	}()
-
 }
 
 func (c *Command) cleanup() {
@@ -173,8 +172,9 @@ func (c *Command) cleanup() {
 
 func createInvocationMetric(cmd *cobra.Command) error {
 	// Create a counter metric
+	metricName := "cli-" + internal.GetRootCmdName(cmd) + "-invocations"
 	counter, err := GetMeter().Int64Counter(
-		internal.ParseCmdName(cmd),
+		metricName,
 		metric.WithDescription("Command Invocation"),
 		metric.WithUnit("1"),
 	)
@@ -184,6 +184,7 @@ func createInvocationMetric(cmd *cobra.Command) error {
 
 	attributes := internal.ParseCmdFlagsToAttributes(cmd)
 	attributes = append(attributes, attribute.Bool("tty", internal.IsTTY()))
+	attributes = append(attributes, attribute.String("command", internal.ParseCmdName(cmd)))
 
 	attributeSet, _ := attribute.NewSetWithFiltered(attributes, nil)
 


### PR DESCRIPTION
Thinking about how this would be displayed and reported, we most likely need a single known-named metric to be emitted here versus N metrics for each command/subcommand executed from a program.

Previous functionality would emit metrics like this (in prometheus format):

```
root_total{job="example",tty="true"} 2
account_mgmt_list_total{job="example",my_flag_arg="1",tty="true"} 1
```

from the commands:

```
example
example
example account mgmt list --my-flag-arg somevalue
```

Note, though, that there are two separate metrics emitted. Trying to think about how we build dashboards for this given the data is going to be stored in prometheus and this gets tricky, and I believe it's "expensive" resource-wise to do a query for all metrics that have a specific label. In this case, we'd have to query for something like `WHERE job=example` - but there's nothing saying there may not be metrics in our dataset that may not be ours or from our CLI that we'd also be getting. Additionally, I'm not sure what the level of ability to run transforms in dashboard tools like Grafana would be on the metric names themselves, for things like grouping. Like, with the example dataset above would I be able to transform and know how often the `account` subcommand, INCLUDING it's subcommands are called? Not sure.

So, this PR changes the functionality to go to a "well-known" metric, relying a bit more on labels to give the intended functionality:

From the same command set above, the new output would be as follows:
```
cli_example_invocations_total{command="root",job="example",tty="true"} 2
cli_example_invocations_total{command="account-mgmt-list",job="example",my_flag_arg="1",tty="true"} 1
```